### PR TITLE
Todoカードの作成

### DIFF
--- a/src/components/Todo/Todo.vue
+++ b/src/components/Todo/Todo.vue
@@ -10,7 +10,7 @@
 
         <v-layout align-center justify-center class="card-inside">
           <v-flex xs2 grow class="height : 35px">
-            <v-checkbox class="checkbox" @click.stop="todo.endOfTodo = !todo.endOfTodo"></v-checkbox>
+            <v-checkbox class="checkbox" :value="todo.endOfTodo" @click.stop="todo.endOfTodo = !todo.endOfTodo"></v-checkbox>
           </v-flex>
           <v-flex>
             <v-list-tile-action>

--- a/src/components/Todo/Todo.vue
+++ b/src/components/Todo/Todo.vue
@@ -30,8 +30,12 @@
         </v-card-title>
         <v-divider></v-divider>
         <v-card-text class="modal-todo-text">{{ todo.text }}</v-card-text>
-				
         <v-card-text class="modal-todo-date">作成日: {{ todo.date }}</v-card-text>
+        <v-divider></v-divider>
+          <v-card-actions>
+            <v-checkbox class="modal-checkbox" v-model="todo.endOfTodo"></v-checkbox>
+            <v-btn color="error">削除</v-btn>
+          </v-card-actions>
       </v-card>
     </v-dialog>
   </div>
@@ -74,9 +78,16 @@ export default {
   font-size: 20px;
 }
 .modal-todo-text {
+  font-size: 16px;
 }
 .modal-todo-date {
-	color: gray;
+  color: gray;
+  font-size: 13px;
   text-align: right;
+}
+.modal-checkbox {
+  height: 34px;
+	margin: 10px 0 0px 0;
+  padding-top: 0px;
 }
 </style>

--- a/src/components/Todo/Todo.vue
+++ b/src/components/Todo/Todo.vue
@@ -31,7 +31,7 @@
         <v-divider></v-divider>
         <v-card-text class="modal-todo-text">{{ todo.text }}</v-card-text>
 				
-        <v-card-text class="modal-todo-date">{{ todo.date }}</v-card-text>
+        <v-card-text class="modal-todo-date">作成日: {{ todo.date }}</v-card-text>
       </v-card>
     </v-dialog>
   </div>
@@ -76,6 +76,7 @@ export default {
 .modal-todo-text {
 }
 .modal-todo-date {
+	color: gray;
   text-align: right;
 }
 </style>

--- a/src/components/Todo/Todo.vue
+++ b/src/components/Todo/Todo.vue
@@ -63,20 +63,5 @@ export default {
   vertical-align: middle;
 }
 
-.modal-todo-title {
-  font-size: 20px;
-}
-.modal-todo-text {
-  font-size: 16px;
-}
-.modal-todo-date {
-  color: gray;
-  font-size: 13px;
-  text-align: right;
-}
-.modal-checkbox {
-  height: 34px;
-	margin: 10px 0 0px 0;
-  padding-top: 0px;
-}
+
 </style>

--- a/src/components/Todo/Todo.vue
+++ b/src/components/Todo/Todo.vue
@@ -22,31 +22,20 @@
         </v-layout>
       </v-card>
     </v-container>
-
-    <v-dialog v-model="todo.dialog" scrollable max-width="80%" color="primary">
-      <v-card>
-        <v-card-title class="modal-todo-title">
-          <div>{{ todo.title }}</div>
-        </v-card-title>
-        <v-divider></v-divider>
-        <v-card-text class="modal-todo-text">{{ todo.text }}</v-card-text>
-        <v-card-text class="modal-todo-date">作成日: {{ todo.date }}</v-card-text>
-        <v-divider></v-divider>
-          <v-card-actions>
-            <v-checkbox class="modal-checkbox" v-model="todo.endOfTodo"></v-checkbox>
-            <v-btn color="error">削除</v-btn>
-          </v-card-actions>
-      </v-card>
-    </v-dialog>
+		<app-todo-dialog :todo="todo"></app-todo-dialog>
   </div>
 </template>
 
 <script>
+import TodoDialog from "./dialogs/TodoDialog.vue"
 export default {
   props: ["todo"],
   data() {
     return {};
-  }
+  },
+	components: {
+		appTodoDialog: TodoDialog,
+	}
 };
 </script>
 

--- a/src/components/Todo/Todo.vue
+++ b/src/components/Todo/Todo.vue
@@ -23,11 +23,13 @@
       </v-card>
     </v-container>
 		<app-todo-dialog :todo="todo"></app-todo-dialog>
+		<app-delete-dialog :todo="todo"></app-delete-dialog>
   </div>
 </template>
 
 <script>
-import TodoDialog from "./dialogs/TodoDialog.vue"
+import TodoDialog from "./dialogs/TodoDialog.vue";
+import DeleteDialog from "./dialogs/DeleteDialog.vue";
 export default {
   props: ["todo"],
   data() {
@@ -35,6 +37,7 @@ export default {
   },
 	components: {
 		appTodoDialog: TodoDialog,
+		appDeleteDialog: DeleteDialog,
 	}
 };
 </script>

--- a/src/components/Todo/Todo.vue
+++ b/src/components/Todo/Todo.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <v-container xs12 sm6 md3>
-      <v-card hover class="card" width="200px" @click.prevent="todo.todoDialog=true">
+      <v-card hover class="card" width="200px" @click="todo.todoDialog=true">
         <v-layout justify-end class="closeBox">
           <v-btn @click.stop="todo.deleteDialog=true" class="closeBtn" fab small depressed flat>
             <v-icon>far fa-times-circle</v-icon>

--- a/src/components/Todo/Todo.vue
+++ b/src/components/Todo/Todo.vue
@@ -13,7 +13,6 @@
             <v-checkbox
               class="checkbox"
               @click.stop="todo.endOfTodo = !todo.endOfTodo"
-              v-model="todo.endOfTodo"
             ></v-checkbox>
           </v-flex>
           <v-flex>

--- a/src/components/Todo/Todo.vue
+++ b/src/components/Todo/Todo.vue
@@ -25,10 +25,13 @@
 
     <v-dialog v-model="todo.dialog" scrollable max-width="80%" color="primary">
       <v-card>
-        <v-card-title style="font-size: 15px">{{ todo.title }}</v-card-title>
+        <v-card-title class="modal-todo-title">
+          <div>{{ todo.title }}</div>
+        </v-card-title>
         <v-divider></v-divider>
-        <v-card-text>{{ todo.text }}</v-card-text>
-        <v-card-text>{{ todo.date }}</v-card-text>
+        <v-card-text class="modal-todo-text">{{ todo.text }}</v-card-text>
+				
+        <v-card-text class="modal-todo-date">{{ todo.date }}</v-card-text>
       </v-card>
     </v-dialog>
   </div>
@@ -65,5 +68,14 @@ export default {
   height: 50px;
   box-sizing: content-box;
   vertical-align: middle;
+}
+
+.modal-todo-title {
+  font-size: 20px;
+}
+.modal-todo-text {
+}
+.modal-todo-date {
+  text-align: right;
 }
 </style>

--- a/src/components/Todo/Todo.vue
+++ b/src/components/Todo/Todo.vue
@@ -1,19 +1,23 @@
 <template>
   <div>
     <v-container xs12 sm6 md3>
-      <v-card hover class="card" width="200px">
+      <v-card hover class="card" width="200px" @click.prevent="todo.todoDialog=true">
         <v-layout justify-end class="closeBox">
-          <v-btn @click="todo.deleteDialog=true" class="closeBtn" fab small depressed flat>
+          <v-btn @click.stop="todo.deleteDialog=true" class="closeBtn" fab small depressed flat>
             <v-icon>far fa-times-circle</v-icon>
           </v-btn>
         </v-layout>
 
         <v-layout align-center justify-center class="card-inside">
           <v-flex xs2 grow class="height : 35px">
-            <v-checkbox class="checkbox" v-model="todo.endOfTodo"></v-checkbox>
+            <v-checkbox
+              class="checkbox"
+              @click.stop="todo.endOfTodo = !todo.endOfTodo"
+              v-model="todo.endOfTodo"
+            ></v-checkbox>
           </v-flex>
           <v-flex>
-            <v-list-tile-action @click="todo.todoDialog=true">
+            <v-list-tile-action>
               <v-list-tile-content>
                 <v-list-tile-title v-text="todo.title"></v-list-tile-title>
               </v-list-tile-content>
@@ -22,8 +26,8 @@
         </v-layout>
       </v-card>
     </v-container>
-		<app-todo-dialog :todo="todo"></app-todo-dialog>
-		<app-delete-dialog :todo="todo"></app-delete-dialog>
+    <app-todo-dialog :todo="todo"></app-todo-dialog>
+    <app-delete-dialog :todo="todo"></app-delete-dialog>
   </div>
 </template>
 
@@ -35,10 +39,10 @@ export default {
   data() {
     return {};
   },
-	components: {
-		appTodoDialog: TodoDialog,
-		appDeleteDialog: DeleteDialog,
-	}
+  components: {
+    appTodoDialog: TodoDialog,
+    appDeleteDialog: DeleteDialog
+  }
 };
 </script>
 
@@ -65,6 +69,4 @@ export default {
   box-sizing: content-box;
   vertical-align: middle;
 }
-
-
 </style>

--- a/src/components/Todo/Todo.vue
+++ b/src/components/Todo/Todo.vue
@@ -3,7 +3,7 @@
     <v-container xs12 sm6 md3>
       <v-card hover class="card" width="200px">
         <v-layout justify-end class="closeBox">
-          <v-btn class="closeBtn" fab small depressed flat>
+          <v-btn @click="todo.deleteDialog=true" class="closeBtn" fab small depressed flat>
             <v-icon>far fa-times-circle</v-icon>
           </v-btn>
         </v-layout>
@@ -13,7 +13,7 @@
             <v-checkbox class="checkbox" v-model="todo.endOfTodo"></v-checkbox>
           </v-flex>
           <v-flex>
-            <v-list-tile-action @click="todo.dialog=true">
+            <v-list-tile-action @click="todo.todoDialog=true">
               <v-list-tile-content>
                 <v-list-tile-title v-text="todo.title"></v-list-tile-title>
               </v-list-tile-content>

--- a/src/components/Todo/Todo.vue
+++ b/src/components/Todo/Todo.vue
@@ -9,7 +9,7 @@
         </v-layout>
 
         <v-layout align-center justify-center class="card-inside">
-          <v-flex xs2 grow class="height : 35px">
+          <v-flex xs2 grow>
             <v-checkbox class="checkbox" :value="todo.endOfTodo" @click.stop="todo.endOfTodo = !todo.endOfTodo"></v-checkbox>
           </v-flex>
           <v-flex>

--- a/src/components/Todo/Todo.vue
+++ b/src/components/Todo/Todo.vue
@@ -10,10 +10,7 @@
 
         <v-layout align-center justify-center class="card-inside">
           <v-flex xs2 grow class="height : 35px">
-            <v-checkbox
-              class="checkbox"
-              @click.stop="todo.endOfTodo = !todo.endOfTodo"
-            ></v-checkbox>
+            <v-checkbox class="checkbox" @click.stop="todo.endOfTodo = !todo.endOfTodo"></v-checkbox>
           </v-flex>
           <v-flex>
             <v-list-tile-action>

--- a/src/components/Todo/Todo.vue
+++ b/src/components/Todo/Todo.vue
@@ -2,8 +2,14 @@
   <div>
     <v-container xs12 sm6 md3>
       <v-card hover class="card" width="200px">
-        <v-layout align-center justify-center>
-          <v-flex xs2 grow>
+        <v-layout justify-end class="closeBox">
+          <v-btn class="closeBtn" fab small depressed flat>
+            <v-icon>far fa-times-circle</v-icon>
+          </v-btn>
+        </v-layout>
+
+        <v-layout align-center justify-center class="card-inside">
+          <v-flex xs2 grow class="height : 35px">
             <v-checkbox class="checkbox" v-model="todo.endOfTodo"></v-checkbox>
           </v-flex>
           <v-flex>
@@ -43,5 +49,21 @@ export default {
   color: gray;
   background-color: transparent;
   padding: 0 10px;
+}
+.closeBox {
+  height: 15px;
+  width: 190px;
+  text-align: center;
+}
+
+.closeBtn {
+  height: 30px;
+  width: 30px;
+  color: gray;
+}
+.card-inside {
+  height: 50px;
+  box-sizing: content-box;
+  vertical-align: middle;
 }
 </style>

--- a/src/components/Todo/Todos.vue
+++ b/src/components/Todo/Todos.vue
@@ -9,7 +9,7 @@
 <script>
 import Todo from "./Todo.vue";
 import moment from "moment";
-moment.locale('ja')
+moment.locale("ja");
 export default {
   data() {
     return {
@@ -19,40 +19,45 @@ export default {
           title: "課題を行う",
           text: "Todoリストのインプットフォーム",
           date: moment().format("YYYY年 MM月 Do(ddd), kk時mm分 "),
-          dialog: false,
-          endOfTodo: false
+          todoDialog: false,
+          endOfTodo: false,
+          deleteDialog: false
         },
         {
           id: 2,
           title: "ご飯を買いに行く",
           text: "今日は中華",
           date: moment().format("YYYY年 MM月 Do(ddd), kk時mm分 "),
-          dialog: false,
-          endOfTodo: false
+          todoDialog: false,
+          endOfTodo: false,
+          deleteDialog: false
         },
         {
           id: 3,
           title: "友達と遊ぶ",
           text: "ゲームセンターに集合",
           date: moment().format("YYYY年 MM月 Do(ddd), kk時mm分 "),
-          dialog: false,
-          endOfTodo: false
+          todoDialog: false,
+          endOfTodo: false,
+          deleteDialog: false
         },
         {
           id: 4,
           title: "風呂を入れる",
           text: "温泉の素を入れる",
           date: moment().format("YYYY年 MM月 Do(ddd), kk時mm分 "),
-          dialog: false,
-          endOfTodo: false
+          todoDialog: false,
+          endOfTodo: false,
+          deleteDialog: false
         },
         {
           id: 5,
           title: "課題を行う",
           text: "TodoリストのTodo部分",
           date: moment().format("YYYY年 MM月 Do(ddd), kk時mm分 "),
-          dialog: false,
-          endOfTodo: false
+          todoDialog: false,
+          endOfTodo: false,
+          deleteDialog: false
         }
       ]
     };

--- a/src/components/Todo/Todos.vue
+++ b/src/components/Todo/Todos.vue
@@ -9,6 +9,7 @@
 <script>
 import Todo from "./Todo.vue";
 import moment from "moment";
+moment.locale('ja')
 export default {
   data() {
     return {
@@ -17,7 +18,7 @@ export default {
           id: 1,
           title: "課題を行う",
           text: "Todoリストのインプットフォーム",
-          date: moment().format("MMMM Do YYYY, h:mm:ss a"),
+          date: moment().format("YYYY年 MM月 Do(ddd), kk時mm分 "),
           dialog: false,
           endOfTodo: false
         },
@@ -25,7 +26,7 @@ export default {
           id: 2,
           title: "ご飯を買いに行く",
           text: "今日は中華",
-          date: moment().format("MMMM Do YYYY, h:mm:ss a"),
+          date: moment().format("YYYY年 MM月 Do(ddd), kk時mm分 "),
           dialog: false,
           endOfTodo: false
         },
@@ -33,7 +34,7 @@ export default {
           id: 3,
           title: "友達と遊ぶ",
           text: "ゲームセンターに集合",
-          date: moment().format("MMMM Do YYYY, h:mm:ss a"),
+          date: moment().format("YYYY年 MM月 Do(ddd), kk時mm分 "),
           dialog: false,
           endOfTodo: false
         },
@@ -41,7 +42,7 @@ export default {
           id: 4,
           title: "風呂を入れる",
           text: "温泉の素を入れる",
-          date: moment().format("MMMM Do YYYY, h:mm:ss a"),
+          date: moment().format("YYYY年 MM月 Do(ddd), kk時mm分 "),
           dialog: false,
           endOfTodo: false
         },
@@ -49,7 +50,7 @@ export default {
           id: 5,
           title: "課題を行う",
           text: "TodoリストのTodo部分",
-          date: moment().format("MMMM Do YYYY, h:mm:ss a"),
+          date: moment().format("YYYY年 MM月 Do(ddd), kk時mm分 "),
           dialog: false,
           endOfTodo: false
         }

--- a/src/components/Todo/dialogs/DeleteDialog.vue
+++ b/src/components/Todo/dialogs/DeleteDialog.vue
@@ -1,0 +1,5 @@
+<template>
+	<div>
+		
+	</div>
+</template>

--- a/src/components/Todo/dialogs/DeleteDialog.vue
+++ b/src/components/Todo/dialogs/DeleteDialog.vue
@@ -1,5 +1,3 @@
 <template>
-	<div>
-		
-	</div>
+  <v-dialog v-model="todo.deleteDialog" scrollable max-width="50%"></v-dialog>
 </template>

--- a/src/components/Todo/dialogs/DeleteDialog.vue
+++ b/src/components/Todo/dialogs/DeleteDialog.vue
@@ -1,20 +1,20 @@
 <template>
   <v-dialog v-model="todo.deleteDialog" scrollable max-width="50%">
-		<v-card>
-			<v-card-title >
-				<strong>"{{ todo.title }}"</strong>を削除しますか？
-			</v-card-title>
-			<v-card-actions>
-				<v-spacer></v-spacer>
-				<v-btn color="red" flat>はい</v-btn>
-				<v-btn color="gray" flat @click="todo.deleteDialog = false">いいえ</v-btn>
-			</v-card-actions>
-		</v-card>
-	</v-dialog>
+    <v-card>
+      <v-card-title>
+        <strong>"{{ todo.title }}"</strong>を削除しますか？
+      </v-card-title>
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn color="red" flat>はい</v-btn>
+        <v-btn color="gray" flat @click="todo.deleteDialog = false">いいえ</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
 </template>
 
 <script>
 export default {
-	props: ['todo']
-}
+  props: ["todo"]
+};
 </script>

--- a/src/components/Todo/dialogs/DeleteDialog.vue
+++ b/src/components/Todo/dialogs/DeleteDialog.vue
@@ -1,3 +1,15 @@
 <template>
-  <v-dialog v-model="todo.deleteDialog" scrollable max-width="50%"></v-dialog>
+  <v-dialog v-model="todo.deleteDialog" scrollable max-width="50%">
+		<v-card>
+			<v-card-title >
+				Todoを削除しますか？
+			</v-card-title>
+		</v-card>
+	</v-dialog>
 </template>
+
+<script>
+export default {
+	props: ['todo']
+}
+</script>

--- a/src/components/Todo/dialogs/DeleteDialog.vue
+++ b/src/components/Todo/dialogs/DeleteDialog.vue
@@ -7,7 +7,7 @@
 			<v-card-actions>
 				<v-spacer></v-spacer>
 				<v-btn color="red" flat>はい</v-btn>
-				<v-btn color="primary" flat>いいえ</v-btn>
+				<v-btn color="primary" flat @click="todo.deleteDialog = false">いいえ</v-btn>
 			</v-card-actions>
 		</v-card>
 	</v-dialog>

--- a/src/components/Todo/dialogs/DeleteDialog.vue
+++ b/src/components/Todo/dialogs/DeleteDialog.vue
@@ -7,7 +7,7 @@
 			<v-card-actions>
 				<v-spacer></v-spacer>
 				<v-btn color="red" flat>はい</v-btn>
-				<v-btn color="primary" flat @click="todo.deleteDialog = false">いいえ</v-btn>
+				<v-btn color="gray" flat @click="todo.deleteDialog = false">いいえ</v-btn>
 			</v-card-actions>
 		</v-card>
 	</v-dialog>

--- a/src/components/Todo/dialogs/DeleteDialog.vue
+++ b/src/components/Todo/dialogs/DeleteDialog.vue
@@ -2,8 +2,13 @@
   <v-dialog v-model="todo.deleteDialog" scrollable max-width="50%">
 		<v-card>
 			<v-card-title >
-				Todoを削除しますか？
+				<strong>"{{ todo.title }}"</strong>を削除しますか？
 			</v-card-title>
+			<v-card-actions>
+				<v-spacer></v-spacer>
+				<v-btn color="red" flat>はい</v-btn>
+				<v-btn color="primary" flat>いいえ</v-btn>
+			</v-card-actions>
 		</v-card>
 	</v-dialog>
 </template>

--- a/src/components/Todo/dialogs/TodoDialog.vue
+++ b/src/components/Todo/dialogs/TodoDialog.vue
@@ -7,10 +7,10 @@
       <v-divider></v-divider>
       <v-card-text class="modal-todo-text">{{ todo.text }}</v-card-text>
       <v-card-text class="modal-todo-date">作成日: {{ todo.date }}</v-card-text>
-      <v-divider></v-divider>
+		<v-spacer></v-spacer>
       <v-card-actions>
         <v-checkbox class="modal-checkbox" v-model="todo.endOfTodo"></v-checkbox>
-        <v-btn color="error" @click="todo.deleteDialog=true">削除</v-btn>
+        <v-btn color="red" flat @click="todo.deleteDialog=true">削除</v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>
@@ -37,6 +37,6 @@ export default {
 .modal-checkbox {
   height: 34px;
   margin: 10px 0 0px 0;
-  padding-top: 0px;
+  padding: 0 0 0 10px;
 }
 </style>

--- a/src/components/Todo/dialogs/TodoDialog.vue
+++ b/src/components/Todo/dialogs/TodoDialog.vue
@@ -10,8 +10,6 @@
       <v-spacer></v-spacer>
       <v-card-actions>
         <v-checkbox class="modal-checkbox" v-model="todo.endOfTodo"></v-checkbox>
-        <v-checkbox class="modal-checkbox" v-model="todo.endOfTodo"></v-checkbox>
-
         <v-btn color="red" flat @click.passive="todo.deleteDialog=true">削除</v-btn>
       </v-card-actions>
     </v-card>

--- a/src/components/Todo/dialogs/TodoDialog.vue
+++ b/src/components/Todo/dialogs/TodoDialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog v-model="todo.dialog" scrollable max-width="50%" color="primary">
+  <v-dialog v-model="todo.dialog" scrollable max-width="50%">
     <v-card>
       <v-card-title class="modal-todo-title">
         <div>{{ todo.title }}</div>

--- a/src/components/Todo/dialogs/TodoDialog.vue
+++ b/src/components/Todo/dialogs/TodoDialog.vue
@@ -1,0 +1,23 @@
+<template>
+  <v-dialog v-model="todo.dialog" scrollable max-width="50%" color="primary">
+    <v-card>
+      <v-card-title class="modal-todo-title">
+        <div>{{ todo.title }}</div>
+      </v-card-title>
+      <v-divider></v-divider>
+      <v-card-text class="modal-todo-text">{{ todo.text }}</v-card-text>
+      <v-card-text class="modal-todo-date">作成日: {{ todo.date }}</v-card-text>
+      <v-divider></v-divider>
+      <v-card-actions>
+        <v-checkbox class="modal-checkbox" v-model="todo.endOfTodo"></v-checkbox>
+        <v-btn color="error">削除</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+export default {
+	props:['todo']
+}
+</script>

--- a/src/components/Todo/dialogs/TodoDialog.vue
+++ b/src/components/Todo/dialogs/TodoDialog.vue
@@ -18,6 +18,25 @@
 
 <script>
 export default {
-	props:['todo']
-}
+  props: ["todo"]
+};
 </script>
+
+<style scoped>
+.modal-todo-title {
+  font-size: 20px;
+}
+.modal-todo-text {
+  font-size: 16px;
+}
+.modal-todo-date {
+  color: gray;
+  font-size: 13px;
+  text-align: right;
+}
+.modal-checkbox {
+  height: 34px;
+  margin: 10px 0 0px 0;
+  padding-top: 0px;
+}
+</style>

--- a/src/components/Todo/dialogs/TodoDialog.vue
+++ b/src/components/Todo/dialogs/TodoDialog.vue
@@ -7,9 +7,11 @@
       <v-divider></v-divider>
       <v-card-text class="modal-todo-text">{{ todo.text }}</v-card-text>
       <v-card-text class="modal-todo-date">作成日: {{ todo.date }}</v-card-text>
-		<v-spacer></v-spacer>
+      <v-spacer></v-spacer>
       <v-card-actions>
-        <v-checkbox class="modal-checkbox" v-model="todo.endOfTodo"></v-checkbox>
+        <v-flex>
+          <v-checkbox class="modal-checkbox" v-model="todo.endOfTodo"></v-checkbox>
+        </v-flex>
         <v-btn color="red" flat @click="todo.deleteDialog=true">削除</v-btn>
       </v-card-actions>
     </v-card>

--- a/src/components/Todo/dialogs/TodoDialog.vue
+++ b/src/components/Todo/dialogs/TodoDialog.vue
@@ -9,10 +9,10 @@
       <v-card-text class="modal-todo-date">作成日: {{ todo.date }}</v-card-text>
       <v-spacer></v-spacer>
       <v-card-actions>
-        <v-flex>
-          <v-checkbox class="modal-checkbox" v-model="todo.endOfTodo"></v-checkbox>
-        </v-flex>
-        <v-btn color="red" flat @click="todo.deleteDialog=true">削除</v-btn>
+        <v-checkbox class="modal-checkbox" v-model="todo.endOfTodo"></v-checkbox>
+        <v-checkbox class="modal-checkbox" v-model="todo.endOfTodo"></v-checkbox>
+
+        <v-btn color="red" flat @click.passive="todo.deleteDialog=true">削除</v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>

--- a/src/components/Todo/dialogs/TodoDialog.vue
+++ b/src/components/Todo/dialogs/TodoDialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog v-model="todo.dialog" scrollable max-width="50%">
+  <v-dialog v-model="todo.todoDialog" scrollable max-width="50%">
     <v-card>
       <v-card-title class="modal-todo-title">
         <div>{{ todo.title }}</div>
@@ -10,7 +10,7 @@
       <v-divider></v-divider>
       <v-card-actions>
         <v-checkbox class="modal-checkbox" v-model="todo.endOfTodo"></v-checkbox>
-        <v-btn color="error">削除</v-btn>
+        <v-btn color="error" @click="todo.deleteDialog=true">削除</v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>


### PR DESCRIPTION
#2 で少し作っていたTodoカードを完成させました

#  メイン画面

- Todoのタイトル
- チェックボックス
- デリートボタン

文字部分をクリックすると、Todoモーダルが表示されます。
デリートボタンを押すと、デリートモーダルが表示されます

## 課題
文字部分のみではなくカード全体をクリックしたらモーダルを表示できるようにしたい。（前回できていたと思ったのだができてなかった？前回のコードで試してみても文字部分のみイベントが実行される）
しかしカード全体にイベントを付与すると、チェックボックスとデリートボタンクリック時にもモーダルが表示されてしまう。
解決策が見つからないのと、今回はあくまでモックアップなので細かい実装は後回しにしました。

# Todoモーダル画面

- タイトル
- テキスト
- 作成日付
- チェックボックス
- デリートボタン

チェックボックスは、Todo内の値で制御しているので、メイン、モーダルで連動します。
デリートボタンを押すと、デリートモーダルが表示されます。

## 課題点

削除ボタンを押すとなぜかチェックボックスもクリックアニメーションが実行される。
`v-card-actions`でまとめているのが原因かと思い別々にしたが変わらず

# デリートモーダル画面

- 削除の確認
- はい、いいえボタン

「{todoのタイトル}を削除しますか？」という風に表示します。
いいえを押すと`todo.deleteDialog`が`false`になり、モーダルが閉じます。
gif録画後に、デリートモーダルの「いいえ」ボタンを灰色にしました（赤と青だと紛らわしいため）

![Todoの動き2](https://user-images.githubusercontent.com/46712701/61104734-593fd400-a4b2-11e9-9d5b-d317a5456c25.gif)
