### PR TITLE
モーダルの表示方法の変更

### DIFF
--- a/src/components/Todo/Todo.vue
+++ b/src/components/Todo/Todo.vue
@@ -3,7 +3,7 @@
     <v-container xs12 sm6 md3>
       <v-card hover class="card" width="200px" @click="showTodoDialog(todo)">
         <v-layout justify-end class="closeBox">
-          <v-btn @click.stop="todo.deleteDialog=true" class="closeBtn" fab small depressed flat>
+          <v-btn @click.stop="showDeleteDialog(todo)" class="closeBtn" fab small depressed flat>
             <v-icon>far fa-times-circle</v-icon>
           </v-btn>
         </v-layout>
@@ -23,7 +23,7 @@
       </v-card>
     </v-container>
     <app-todo-dialog :todo="selectedTodo" ref="todoDialog"></app-todo-dialog>
-    <app-delete-dialog :todo="selectedTodo"></app-delete-dialog>
+    <app-delete-dialog :todo="selectedTodo" ref="deleteDialog"></app-delete-dialog>
   </div>
 </template>
 
@@ -40,6 +40,10 @@ export default {
 	methods: {
 		showTodoDialog(todo) {
 			this.$refs.todoDialog.open();
+			this.selectedTodo = todo;
+		},
+		showDeleteDialog(todo) {
+			this.$refs.deleteDialog.open();
 			this.selectedTodo = todo;
 		}
 	},

--- a/src/components/Todo/Todo.vue
+++ b/src/components/Todo/Todo.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <v-container xs12 sm6 md3>
-      <v-card hover class="card" width="200px" @click="todo.todoDialog=true">
+      <v-card hover class="card" width="200px" @click="showTodoDialog(todo)">
         <v-layout justify-end class="closeBox">
           <v-btn @click.stop="todo.deleteDialog=true" class="closeBtn" fab small depressed flat>
             <v-icon>far fa-times-circle</v-icon>
@@ -22,8 +22,8 @@
         </v-layout>
       </v-card>
     </v-container>
-    <app-todo-dialog :todo="todo"></app-todo-dialog>
-    <app-delete-dialog :todo="todo"></app-delete-dialog>
+    <app-todo-dialog :todo="selectedTodo" ref="todoDialog"></app-todo-dialog>
+    <app-delete-dialog :todo="selectedTodo"></app-delete-dialog>
   </div>
 </template>
 
@@ -33,8 +33,16 @@ import DeleteDialog from "./dialogs/DeleteDialog.vue";
 export default {
   props: ["todo"],
   data() {
-    return {};
+    return {
+			selectedTodo: {}
+		};
   },
+	methods: {
+		showTodoDialog(todo) {
+			this.$refs.todoDialog.open();
+			this.selectedTodo = todo;
+		}
+	},
   components: {
     appTodoDialog: TodoDialog,
     appDeleteDialog: DeleteDialog

--- a/src/components/Todo/Todo.vue
+++ b/src/components/Todo/Todo.vue
@@ -10,7 +10,11 @@
 
         <v-layout align-center justify-center class="card-inside">
           <v-flex xs2 grow>
-            <v-checkbox class="checkbox" :value="todo.endOfTodo" @click.stop="todo.endOfTodo = !todo.endOfTodo"></v-checkbox>
+            <v-checkbox
+              class="checkbox"
+              :value="todo.endOfTodo"
+              @click.stop="todo.endOfTodo = !todo.endOfTodo"
+            ></v-checkbox>
           </v-flex>
           <v-flex>
             <v-list-tile-action>
@@ -34,19 +38,19 @@ export default {
   props: ["todo"],
   data() {
     return {
-			selectedTodo: {}
-		};
+      selectedTodo: {}
+    };
   },
-	methods: {
-		showTodoDialog(todo) {
-			this.$refs.todoDialog.open();
-			this.selectedTodo = todo;
-		},
-		showDeleteDialog(todo) {
-			this.$refs.deleteDialog.open();
-			this.selectedTodo = todo;
-		}
-	},
+  methods: {
+    showTodoDialog(todo) {
+      this.$refs.todoDialog.open();
+      this.selectedTodo = todo;
+    },
+    showDeleteDialog(todo) {
+      this.$refs.deleteDialog.open();
+      this.selectedTodo = todo;
+    }
+  },
   components: {
     appTodoDialog: TodoDialog,
     appDeleteDialog: DeleteDialog

--- a/src/components/Todo/Todos.vue
+++ b/src/components/Todo/Todos.vue
@@ -19,35 +19,35 @@ export default {
           title: "課題を行う",
           text: "Todoリストのインプットフォーム",
           date: moment().format("YYYY年 MM月 Do(ddd), kk時mm分 "),
-          endOfTodo: false,
+          endOfTodo: false
         },
         {
           id: 2,
           title: "ご飯を買いに行く",
           text: "今日は中華",
           date: moment().format("YYYY年 MM月 Do(ddd), kk時mm分 "),
-          endOfTodo: false,
+          endOfTodo: false
         },
         {
           id: 3,
           title: "友達と遊ぶ",
           text: "ゲームセンターに集合",
           date: moment().format("YYYY年 MM月 Do(ddd), kk時mm分 "),
-          endOfTodo: false,
+          endOfTodo: false
         },
         {
           id: 4,
           title: "風呂を入れる",
           text: "温泉の素を入れる",
           date: moment().format("YYYY年 MM月 Do(ddd), kk時mm分 "),
-          endOfTodo: false,
+          endOfTodo: false
         },
         {
           id: 5,
           title: "課題を行う",
           text: "TodoリストのTodo部分",
           date: moment().format("YYYY年 MM月 Do(ddd), kk時mm分 "),
-          endOfTodo: false,
+          endOfTodo: false
         }
       ]
     };

--- a/src/components/Todo/Todos.vue
+++ b/src/components/Todo/Todos.vue
@@ -20,7 +20,6 @@ export default {
           text: "Todoリストのインプットフォーム",
           date: moment().format("YYYY年 MM月 Do(ddd), kk時mm分 "),
           endOfTodo: false,
-          deleteDialog: false
         },
         {
           id: 2,
@@ -28,7 +27,6 @@ export default {
           text: "今日は中華",
           date: moment().format("YYYY年 MM月 Do(ddd), kk時mm分 "),
           endOfTodo: false,
-          deleteDialog: false
         },
         {
           id: 3,
@@ -36,7 +34,6 @@ export default {
           text: "ゲームセンターに集合",
           date: moment().format("YYYY年 MM月 Do(ddd), kk時mm分 "),
           endOfTodo: false,
-          deleteDialog: false
         },
         {
           id: 4,
@@ -44,7 +41,6 @@ export default {
           text: "温泉の素を入れる",
           date: moment().format("YYYY年 MM月 Do(ddd), kk時mm分 "),
           endOfTodo: false,
-          deleteDialog: false
         },
         {
           id: 5,
@@ -52,7 +48,6 @@ export default {
           text: "TodoリストのTodo部分",
           date: moment().format("YYYY年 MM月 Do(ddd), kk時mm分 "),
           endOfTodo: false,
-          deleteDialog: false
         }
       ]
     };

--- a/src/components/Todo/Todos.vue
+++ b/src/components/Todo/Todos.vue
@@ -19,7 +19,6 @@ export default {
           title: "課題を行う",
           text: "Todoリストのインプットフォーム",
           date: moment().format("YYYY年 MM月 Do(ddd), kk時mm分 "),
-          todoDialog: false,
           endOfTodo: false,
           deleteDialog: false
         },
@@ -28,7 +27,6 @@ export default {
           title: "ご飯を買いに行く",
           text: "今日は中華",
           date: moment().format("YYYY年 MM月 Do(ddd), kk時mm分 "),
-          todoDialog: false,
           endOfTodo: false,
           deleteDialog: false
         },
@@ -37,7 +35,6 @@ export default {
           title: "友達と遊ぶ",
           text: "ゲームセンターに集合",
           date: moment().format("YYYY年 MM月 Do(ddd), kk時mm分 "),
-          todoDialog: false,
           endOfTodo: false,
           deleteDialog: false
         },
@@ -46,7 +43,6 @@ export default {
           title: "風呂を入れる",
           text: "温泉の素を入れる",
           date: moment().format("YYYY年 MM月 Do(ddd), kk時mm分 "),
-          todoDialog: false,
           endOfTodo: false,
           deleteDialog: false
         },
@@ -55,7 +51,6 @@ export default {
           title: "課題を行う",
           text: "TodoリストのTodo部分",
           date: moment().format("YYYY年 MM月 Do(ddd), kk時mm分 "),
-          todoDialog: false,
           endOfTodo: false,
           deleteDialog: false
         }

--- a/src/components/Todo/dialogs/DeleteDialog.vue
+++ b/src/components/Todo/dialogs/DeleteDialog.vue
@@ -16,18 +16,18 @@
 <script>
 export default {
   props: ["todo"],
-	data() {
-		return {
-			dialog: false
-		};
-	},
-	methods: {
-		open() {
-			this.dialog = true;
-		},
-		close() {
-			this.dialog = false;
-		}
-	}
+  data() {
+    return {
+      dialog: false
+    };
+  },
+  methods: {
+    open() {
+      this.dialog = true;
+    },
+    close() {
+      this.dialog = false;
+    }
+  }
 };
 </script>

--- a/src/components/Todo/dialogs/DeleteDialog.vue
+++ b/src/components/Todo/dialogs/DeleteDialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog v-model="todo.deleteDialog" scrollable max-width="50%">
+  <v-dialog v-model="dialog" scrollable max-width="50%">
     <v-card>
       <v-card-title>
         <strong>"{{ todo.title }}"</strong>を削除しますか？
@@ -7,7 +7,7 @@
       <v-card-actions>
         <v-spacer></v-spacer>
         <v-btn color="red" flat>はい</v-btn>
-        <v-btn color="gray" flat @click="todo.deleteDialog = false">いいえ</v-btn>
+        <v-btn color="gray" flat @click="close()">いいえ</v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>
@@ -15,6 +15,19 @@
 
 <script>
 export default {
-  props: ["todo"]
+  props: ["todo"],
+	data() {
+		return {
+			dialog: false
+		};
+	},
+	methods: {
+		open() {
+			this.dialog = true;
+		},
+		close() {
+			this.dialog = false;
+		}
+	}
 };
 </script>

--- a/src/components/Todo/dialogs/DeleteDialog.vue
+++ b/src/components/Todo/dialogs/DeleteDialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog v-model="dialog" scrollable max-width="50%">
+  <v-dialog v-model="isOpen" scrollable max-width="50%">
     <v-card>
       <v-card-title>
         <strong>"{{ todo.title }}"</strong>を削除しますか？
@@ -18,15 +18,15 @@ export default {
   props: ["todo"],
   data() {
     return {
-      dialog: false
+      isOpen: false
     };
   },
   methods: {
     open() {
-      this.dialog = true;
+      this.isOpen = true;
     },
     close() {
-      this.dialog = false;
+      this.isOpen = false;
     }
   }
 };

--- a/src/components/Todo/dialogs/TodoDialog.vue
+++ b/src/components/Todo/dialogs/TodoDialog.vue
@@ -10,7 +10,7 @@
       <v-spacer></v-spacer>
       <v-card-actions>
         <v-checkbox class="modal-checkbox" v-model="todo.endOfTodo"></v-checkbox>
-				<!-- メソッド作成後コメント外す -->
+        <!-- メソッド作成後コメント外す -->
         <!-- <v-btn color="red" flat @click="todo.deleteDialog=true">削除</v-btn> -->
       </v-card-actions>
     </v-card>
@@ -20,19 +20,19 @@
 <script>
 export default {
   props: ["todo"],
-	data() {
-		return {
-			dialog: false
-		};
-	},
-	methods: {
-		open() {
-			this.dialog = true;
-		},
-		close() {
-			this.dialog = false;
-		}
-	}
+  data() {
+    return {
+      dialog: false
+    };
+  },
+  methods: {
+    open() {
+      this.dialog = true;
+    },
+    close() {
+      this.dialog = false;
+    }
+  }
 };
 </script>
 

--- a/src/components/Todo/dialogs/TodoDialog.vue
+++ b/src/components/Todo/dialogs/TodoDialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog v-model="dialog" scrollable max-width="50%">
+  <v-dialog v-model="isOpen" scrollable max-width="50%">
     <v-card>
       <v-card-title class="modal-todo-title">
         <div>{{ todo.title }}</div>
@@ -22,15 +22,15 @@ export default {
   props: ["todo"],
   data() {
     return {
-      dialog: false
+      isOpen: false
     };
   },
   methods: {
     open() {
-      this.dialog = true;
+      this.isOpen = true;
     },
     close() {
-      this.dialog = false;
+      this.isOpen = false;
     }
   }
 };

--- a/src/components/Todo/dialogs/TodoDialog.vue
+++ b/src/components/Todo/dialogs/TodoDialog.vue
@@ -10,7 +10,8 @@
       <v-spacer></v-spacer>
       <v-card-actions>
         <v-checkbox class="modal-checkbox" v-model="todo.endOfTodo"></v-checkbox>
-        <v-btn color="red" flat @click="todo.deleteDialog=true">削除</v-btn>
+				<!-- メソッド作成後コメント外す -->
+        <!-- <v-btn color="red" flat @click="todo.deleteDialog=true">削除</v-btn> -->
       </v-card-actions>
     </v-card>
   </v-dialog>

--- a/src/components/Todo/dialogs/TodoDialog.vue
+++ b/src/components/Todo/dialogs/TodoDialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog v-model="todo.todoDialog" scrollable max-width="50%">
+  <v-dialog v-model="dialog" scrollable max-width="50%">
     <v-card>
       <v-card-title class="modal-todo-title">
         <div>{{ todo.title }}</div>
@@ -10,7 +10,7 @@
       <v-spacer></v-spacer>
       <v-card-actions>
         <v-checkbox class="modal-checkbox" v-model="todo.endOfTodo"></v-checkbox>
-        <v-btn color="red" flat @click.passive="todo.deleteDialog=true">削除</v-btn>
+        <v-btn color="red" flat @click="todo.deleteDialog=true">削除</v-btn>
       </v-card-actions>
     </v-card>
   </v-dialog>
@@ -18,7 +18,20 @@
 
 <script>
 export default {
-  props: ["todo"]
+  props: ["todo"],
+	data() {
+		return {
+			dialog: false
+		};
+	},
+	methods: {
+		open() {
+			this.dialog = true;
+		},
+		close() {
+			this.dialog = false;
+		}
+	}
 };
 </script>
 


### PR DESCRIPTION
# モーダルの表示方法変更

## propsについて
前回、propsは全て削除予定とコメントしましたが、`v-for`のデータ受け渡しにはpropsが一番都合がよかったので、続行して使い続けることにしました。

## なぜ変更したか
Todoのオブジェクト内ににモーダルの開閉のキーと値があるのはおかしいと思ったので変更しました

## 変更点


### TodoDialog

モーダルのvueファイルに開閉のデータ、メソッドを作成。
`$refs`を使用して、子コンポーネントのデータにアクセスできるようにして、モーダルを開きます。
引数からクリックしたTodoをデータに代入し、モーダルに渡しました。
それに伴い、Todoデータ内のTodoDialog開閉用の値は削除しました

### DeleteDialog
行なっていることはTodoDialogと変わりません

#### 問題点
`$refs`は親コンポーネント→子コンポーネントへアクセスするために使います。
子コンポーネント→子コンポーネントには使用できません。
TodoDialogの削除ボタンからDeleteDialogをオープンすることができなくなりました。

#### 解決点
store経由でデータを変更します。
今はTodoのCRUD機能を作ることが優先なので、とりあえずはボタンを非表示にして、機能作成は後回しにします。
