### PR TITLE
feature/mutations.updateTodoの作成

### DIFF
--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -6,7 +6,7 @@ export default {
     state.todos.push(todo);
   },
   updateTodo(state, editTodo) {
-    const index = state.todos.findIndex(todo => todo.id === editTodo.id);
+    const index = state.todos.findIndex(todo => editTodo.id === todo.id);
     state.todos[index].title = editTodo.title;
     state.todos[index].text = editTodo.text;
   }

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -4,5 +4,10 @@ export default {
   },
   addTodo(state, todo) {
     state.todos.push(todo);
+  },
+  updateTodo(state, editTodo) {
+    const index = state.todos.findIndex(todo => todo.id = editTodo.id)
+    state.todos[index].title = editTodo.title;
+    state.todos[index].text = editTodo.text
   }
 };

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -8,6 +8,6 @@ export default {
   updateTodo(state, editTodo) {
     const index = state.todos.findIndex(todo => todo.id === editTodo.id);
     state.todos[index].title = editTodo.title;
-    state.todos[index].text = editTodo.text
+    state.todos[index].text = editTodo.text;
   }
 };

--- a/tests/unit/store/mutations.spec.js
+++ b/tests/unit/store/mutations.spec.js
@@ -23,6 +23,6 @@ describe("test mutations.js", () => {
     const todo = { id: 3, title: "update title", text: "update text" };
 
     mutations.updateTodo(state, todo);
-    expect(state.todos[2]).toEqual(todo)
+    expect(state.todos[2]).toEqual(todo);
   });
 });

--- a/tests/unit/store/mutations.spec.js
+++ b/tests/unit/store/mutations.spec.js
@@ -14,7 +14,7 @@ describe("test mutations.js", () => {
     expect(state.todos).toEqual(todos);
   });
   it("mutations.addTodoはstate.todosの末尾に第二引数をpushする", () => {
-    const todo = { id: 3, title: "test title3", text: "test text2" };
+    const todo = { id: 3, title: "test title3", text: "test text3" };
 
     mutations.addTodo(state, todo);
     expect(state.todos[2]).toEqual(todo);


### PR DESCRIPTION
# 機能
`state.todos`の配列`todos`内から、updateTodoに渡されたTodoのidと合致するTodoのタイトル、内容を変更する

# テスト
mutations.updateTodoは指定したidと紐つく配列内のtodoを内容を変更する
<img width="472" alt="スクリーンショット 2019-07-18 20 09 10" src="https://user-images.githubusercontent.com/46712701/61452971-f6f64000-a997-11e9-8b0b-ba15b49d1e02.png">
