### PR TITLE
feature/actions.putTodo,todos.updateTodoの作成

### DIFF
--- a/src/data/todos.js
+++ b/src/data/todos.js
@@ -34,5 +34,12 @@ export default {
     });
     todos.push({ ...todo });
     return { ...todo };
+  },
+  updateTodo: editTodo => {
+    const index = todos.findIndex(todo => todo.id === editTodo.id);
+    todos[index].todo.title = editTodo.title;
+    todos[index].todo.text = editTodo.text;
+
+    return todos[index].todo;
   }
 };

--- a/src/data/todos.js
+++ b/src/data/todos.js
@@ -36,10 +36,10 @@ export default {
     return { ...todo };
   },
   updateTodo: editTodo => {
-    const index = todos.findIndex(todo => todo.id === editTodo.id);
-    todos[index].todo.title = editTodo.title;
-    todos[index].todo.text = editTodo.text;
+    const todo = todos.find(todo => editTodo.id === todo.id);
+    todo.title = editTodo.title;
+    todo.text = editTodo.text;
 
-    return todos[index].todo;
+    return todo;
   }
 };

--- a/src/data/todos.js
+++ b/src/data/todos.js
@@ -38,7 +38,7 @@ export default {
   updateTodo: editTodo => {
     const todo = todos.find(todo => editTodo.id === todo.id);
     if(!todo) {
-      throw Error("idと合致するTodoはありません");
+      throw new Error("idと合致するTodoはありません");
     }
     todo.title = editTodo.title;
     todo.text = editTodo.text;

--- a/src/data/todos.js
+++ b/src/data/todos.js
@@ -37,6 +37,9 @@ export default {
   },
   updateTodo: editTodo => {
     const todo = todos.find(todo => editTodo.id === todo.id);
+    if(!todo) {
+      throw Error("idと合致するTodoはありません");
+    }
     todo.title = editTodo.title;
     todo.text = editTodo.text;
 

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -7,5 +7,6 @@ export default {
   postTodo: ({ commit }, { title, text }) => {
     const todo = todos.createTodo({ title, text });
     commit("addTodo", todo);
-  }
+  },
+  putTodo: ({ commit }) => {}
 };

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -13,7 +13,7 @@ export default {
       const todo = todos.updateTodo(editTodo);
       commit("updateTodo", todo);
     } catch (e){
-      throw  Error(e)
+      throw(e)
     }
   }
 };

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -13,7 +13,7 @@ export default {
       const todo = todos.updateTodo(editTodo);
       commit("updateTodo", todo);
     } catch (e){
-      throw(e)
+      throw e
     }
   }
 };

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -8,5 +8,8 @@ export default {
     const todo = todos.createTodo({ title, text });
     commit("addTodo", todo);
   },
-  putTodo: ({ commit }) => {}
+  putTodo: ({ commit }, editTodo) => {
+    const todo = todos.updateTodo(editTodo);
+    commit("updateTodo", todo)
+  }
 };

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -9,7 +9,11 @@ export default {
     commit("addTodo", todo);
   },
   putTodo: ({ commit }, editTodo) => {
-    const todo = todos.updateTodo(editTodo);
-    commit("updateTodo", todo)
+    try {
+      const todo = todos.updateTodo(editTodo);
+      commit("updateTodo", todo);
+    } catch (e){
+      throw  Error(e)
+    }
   }
 };

--- a/tests/unit/store/actions.spec.js
+++ b/tests/unit/store/actions.spec.js
@@ -25,20 +25,25 @@ describe("test actions.js", () => {
       completed: false
     });
   });
-  it("actions.putTodoはmutation.updateTodoにtodoデータを渡す", () => {
+  it("actions.putTodoはmutation.updateTodoにtodoデータを渡す、渡されたデータはidが合致した配列内のtodoを変更している", () => {
     const commit = jest.fn();
-    const todo = {
+    const editTodo = {
       id: 3,
       title: "update title",
       text: "update text"
     };
 
-    actions.putTodo({ commit }, todo);
+    const oldTodos = todos.findAll();
+    const oldTodo = oldTodos.find(todo => todo.id === editTodo.id);
+
+    actions.putTodo({ commit }, editTodo);
 
     expect(commit).toHaveBeenCalledWith("updateTodo", {
-      id: todo.id,
-      title: todo.title,
-      text: todo.text
+      id: editTodo.id,
+      title: editTodo.title,
+      text: editTodo.text,
+      date: oldTodo.date,
+      completed: oldTodo.completed
     });
   });
 });

--- a/tests/unit/store/actions.spec.js
+++ b/tests/unit/store/actions.spec.js
@@ -46,4 +46,16 @@ describe("test actions.js", () => {
       completed: oldTodo.completed
     });
   });
+  it("配列内のTodoに合致するIDがない場合、エラーを返す", () => {
+    const commit = jest.fn();
+    const missingTodo = {
+      id: 999999999999999999,
+      title: "missing title",
+      text: "missing text"
+    };
+
+    expect(() => {
+      actions.putTodo({commit}, missingTodo);
+    }).toThrow("idと合致するTodoはありません");
+  });
 });

--- a/tests/unit/store/actions.spec.js
+++ b/tests/unit/store/actions.spec.js
@@ -25,4 +25,20 @@ describe("test actions.js", () => {
       completed: false
     });
   });
+  it("actions.putTodoはmutation.updateTodoにtodoデータを渡す", () => {
+    const commit = jest.fn();
+    const todo = {
+      id: 3,
+      title: "update title",
+      text: "update text"
+    };
+
+    actions.putTodo({ commit }, todo);
+
+    expect(commit).toHaveBeenCalledWith("updateTodo", {
+      id: todo.id,
+      title: todo.title,
+      text: todo.text
+    });
+  });
 });


### PR DESCRIPTION
# 機能
- actions.putTodo
渡されたTodoデータを`todos.updateTodo`と`mutations.updateTodo`に渡す
- todos.updateTodo
配列todos内から、updateTodoに渡されたTodoのidと合致するTodoのタイトル、内容を変更する

# テスト

## actions.putTodoはmutation.updateTodoにtodoデータを渡す、渡されたデータはidが合致した配列内のtodoを変更している
<img width="472" alt="スクリーンショット 2019-07-18 23 43 29" src="https://user-images.githubusercontent.com/46712701/61467395-801c6f80-a9b6-11e9-8ca2-82adc8812c62.png">


## 配列内のTodoに合致するIDがない場合、エラーを返す

<img width="472" alt="スクリーンショット 2019-07-19 10 47 24" src="https://user-images.githubusercontent.com/46712701/61503629-7b39d900-aa13-11e9-99f5-284a67cfa924.png">

