### PR TITLE
feature/Todo編集フォームの作成

### DIFF
--- a/src/components/Todo/Todo.vue
+++ b/src/components/Todo/Todo.vue
@@ -35,7 +35,15 @@
 import TodoDialog from "./dialogs/TodoDialog.vue";
 import DeleteDialog from "./dialogs/DeleteDialog.vue";
 export default {
-  props: ["todo"],
+  props: {
+    todo: {
+      id: Number,
+      text: String,
+      date: String,
+      todoDialog: Boolean,
+      endOfTodo: Boolean
+    }
+  },
   data() {
     return {
       selectedTodo: {}

--- a/src/components/Todo/dialogs/DeleteDialog.vue
+++ b/src/components/Todo/dialogs/DeleteDialog.vue
@@ -15,7 +15,15 @@
 
 <script>
 export default {
-  props: ["todo"],
+  props: {
+    todo: {
+      id: Number,
+      text: String,
+      date: String,
+      todoDialog: Boolean,
+      endOfTodo: Boolean
+    }
+  },
   data() {
     return {
       isOpen: false

--- a/src/components/Todo/dialogs/TodoDialog.vue
+++ b/src/components/Todo/dialogs/TodoDialog.vue
@@ -60,6 +60,13 @@ export default {
     },
     closeUpdateForm() {
       this.isUpdate = false;
+      this.title = "",
+      this.text = ""
+    }
+  },
+  watch: {
+    isOpen() {
+      this.closeUpdateForm()
     }
   }
 };

--- a/src/components/Todo/dialogs/TodoDialog.vue
+++ b/src/components/Todo/dialogs/TodoDialog.vue
@@ -20,7 +20,15 @@
 
 <script>
 export default {
-  props: ["todo"],
+  props: {
+    todo: {
+      id: Number,
+      text: String,
+      date: String,
+      todoDialog: Boolean,
+      endOfTodo: Boolean
+    }
+  },
   data() {
     return {
       isOpen: false

--- a/src/components/Todo/dialogs/TodoDialog.vue
+++ b/src/components/Todo/dialogs/TodoDialog.vue
@@ -41,6 +41,7 @@ export default {
   },
   data() {
     return {
+      title: "",
       text: "",
       isOpen: false,
       isUpdate: false

--- a/src/components/Todo/dialogs/TodoDialog.vue
+++ b/src/components/Todo/dialogs/TodoDialog.vue
@@ -10,6 +10,7 @@
       <v-spacer></v-spacer>
       <v-card-actions>
         <v-checkbox class="modal-checkbox" v-model="todo.endOfTodo"></v-checkbox>
+        <v-btn color="success">text</v-btn>
         <!-- メソッド作成後コメント外す -->
         <!-- <v-btn color="red" flat @click="todo.deleteDialog=true">削除</v-btn> -->
       </v-card-actions>

--- a/src/components/Todo/dialogs/TodoDialog.vue
+++ b/src/components/Todo/dialogs/TodoDialog.vue
@@ -13,7 +13,10 @@
       <v-spacer></v-spacer>
       <v-card-actions>
         <v-checkbox class="modal-checkbox" v-model="todo.endOfTodo"></v-checkbox>
-        <v-btn color="success" @click="openUpdateForm()">text</v-btn>
+        <v-btn v-if="!isUpdate" color="success" @click="openUpdateForm()" outline>編集</v-btn>
+        <v-btn v-if="isUpdate" color="error" >キャンセル</v-btn>
+        <v-btn v-if="isUpdate" color="info" outline>変更</v-btn>
+
         <!-- メソッド作成後コメント外す -->
         <!-- <v-btn color="red" flat @click="todo.deleteDialog=true">削除</v-btn> -->
       </v-card-actions>

--- a/src/components/Todo/dialogs/TodoDialog.vue
+++ b/src/components/Todo/dialogs/TodoDialog.vue
@@ -1,20 +1,24 @@
 <template>
   <v-dialog v-model="isOpen" scrollable max-width="50%">
     <v-card>
-      <v-card-title class="modal-todo-title">
-        <div v-if="!isUpdate">{{ todo.title }}</div>
+      <v-card-title v-if="!isUpdate" class="modal-todo-title">
+        <div>{{ todo.title }}</div>
       </v-card-title>
-      <v-text-field v-if="isUpdate" v-model="title" label="title" required></v-text-field>
+      <v-card-actions class="update-title" v-if="isUpdate">
+        <v-text-field v-model="title" label="title" required></v-text-field>
+      </v-card-actions>
 
       <v-divider></v-divider>
       <v-card-text v-if="!isUpdate" class="modal-todo-text">{{ todo.text }}</v-card-text>
-      <v-text-field v-if="isUpdate" v-model="text" label="text" required></v-text-field>
+      <v-card-actions v-if="isUpdate">
+        <v-text-field v-model="text" label="text" required></v-text-field>
+      </v-card-actions>
       <v-card-text class="modal-todo-date">作成日: {{ todo.date }}</v-card-text>
       <v-spacer></v-spacer>
       <v-card-actions>
         <v-checkbox class="modal-checkbox" v-model="todo.endOfTodo"></v-checkbox>
         <v-btn v-if="!isUpdate" color="success" @click="openUpdateForm()" outline>編集</v-btn>
-        <v-btn v-if="isUpdate" color="error" >キャンセル</v-btn>
+        <v-btn v-if="isUpdate" color="error" @click="closeUpdateForm()">キャンセル</v-btn>
         <v-btn v-if="isUpdate" color="info" outline>変更</v-btn>
 
         <!-- メソッド作成後コメント外す -->
@@ -53,6 +57,9 @@ export default {
       this.isUpdate = true;
       this.title = this.todo.title;
       this.text = this.todo.text;
+    },
+    closeUpdateForm() {
+      this.isUpdate = false;
     }
   }
 };
@@ -74,5 +81,9 @@ export default {
   height: 34px;
   margin: 10px 0 0px 0;
   padding: 0 0 0 10px;
+}
+
+.update-title {
+  padding-bottom: 0;
 }
 </style>

--- a/src/components/Todo/dialogs/TodoDialog.vue
+++ b/src/components/Todo/dialogs/TodoDialog.vue
@@ -2,15 +2,18 @@
   <v-dialog v-model="isOpen" scrollable max-width="50%">
     <v-card>
       <v-card-title class="modal-todo-title">
-        <div>{{ todo.title }}</div>
+        <div v-if="!isUpdate">{{ todo.title }}</div>
       </v-card-title>
+      <v-text-field v-if="isUpdate" v-model="title" label="title" required></v-text-field>
+
       <v-divider></v-divider>
-      <v-card-text class="modal-todo-text">{{ todo.text }}</v-card-text>
+      <v-card-text v-if="!isUpdate" class="modal-todo-text">{{ todo.text }}</v-card-text>
+      <v-text-field v-if="isUpdate" v-model="text" label="text" required></v-text-field>
       <v-card-text class="modal-todo-date">作成日: {{ todo.date }}</v-card-text>
       <v-spacer></v-spacer>
       <v-card-actions>
         <v-checkbox class="modal-checkbox" v-model="todo.endOfTodo"></v-checkbox>
-        <v-btn color="success">text</v-btn>
+        <v-btn color="success" @click="openUpdateForm()">text</v-btn>
         <!-- メソッド作成後コメント外す -->
         <!-- <v-btn color="red" flat @click="todo.deleteDialog=true">削除</v-btn> -->
       </v-card-actions>
@@ -31,7 +34,9 @@ export default {
   },
   data() {
     return {
-      isOpen: false
+      text: "",
+      isOpen: false,
+      isUpdate: false
     };
   },
   methods: {
@@ -40,6 +45,11 @@ export default {
     },
     close() {
       this.isOpen = false;
+    },
+    openUpdateForm() {
+      this.isUpdate = true;
+      this.title = this.todo.title;
+      this.text = this.todo.text;
     }
   }
 };

--- a/src/components/Todo/dialogs/TodoDialog.vue
+++ b/src/components/Todo/dialogs/TodoDialog.vue
@@ -60,7 +60,8 @@ export default {
     },
     closeUpdateForm() {
       this.isUpdate = false;
-      (this.title = ""), (this.text = "");
+      this.title = "";
+      this.text = "";
     }
   },
   watch: {


### PR DESCRIPTION
# 挙動
Todoモーダル内の編集ボタンをクリックすると、編集用の入力フォーム、ボタンが作成されます。

# watch.isOpan()について
編集画面を開いたままTodoモーダルを閉じると次に開いたときも編集画面のまま開きます。
なので算出プロパティを使用して、モーダル開閉用の`isOpen`関数を監視して、動きがあった場合、`closeUpdateForm`が動作するようになっています。

## 問題点
おそらく、Todoモーダルが閉じる時だけではなく、開く時も裏ではcloseUpdateFormが動作しています。
不要な挙動ですが、現状アプリ自体の不具合は確認されず、編集画面が開きっぱなしの方がよくないと思うのでこのままでいこうと思います(他に何か良い案があれば変更する予定)

![updateTodoフォームの動き](https://user-images.githubusercontent.com/46712701/61520438-287b1400-aa49-11e9-966e-374d536eb8d2.gif)
