### PR TITLE
feature/Todo変更メソッドをvueに組み込み

### DIFF
--- a/src/components/Input.vue
+++ b/src/components/Input.vue
@@ -15,7 +15,7 @@
         </v-layout>
         <v-layout justify-center>
           <v-flex xs12 sm4 md5>
-            <v-text-field label="タイトルを入力してください" v-model="title"></v-text-field>
+            <v-text-field label="タイトルを入力してください" :rules="[v => !!v || 'Item is required']" v-model="title"></v-text-field>
           </v-flex>
           <v-flex xs12 sm4 md5>
             <v-text-field label="内容を入力してください" v-model="text"></v-text-field>

--- a/src/components/Todo/Todo.vue
+++ b/src/components/Todo/Todo.vue
@@ -12,8 +12,8 @@
           <v-flex xs2 grow>
             <v-checkbox
               class="checkbox"
-              :value="todo.endOfTodo"
-              @click.stop="todo.endOfTodo = !todo.endOfTodo"
+              :value="todo.completed"
+              @click.stop="todo.completed = !todo.completed"
             ></v-checkbox>
           </v-flex>
           <v-flex>

--- a/src/components/Todo/Todo.vue
+++ b/src/components/Todo/Todo.vue
@@ -10,6 +10,7 @@
 
         <v-layout align-center justify-center class="card-inside">
           <v-flex xs2 grow>
+            <!-- TODO:Vuex経由でチェックボックスの真偽値を変更する -->
             <v-checkbox
               class="checkbox"
               :value="todo.completed"

--- a/src/components/Todo/dialogs/TodoDialog.vue
+++ b/src/components/Todo/dialogs/TodoDialog.vue
@@ -16,6 +16,7 @@
       <v-card-text class="modal-todo-date">作成日: {{ todo.date }}</v-card-text>
       <v-spacer></v-spacer>
       <v-card-actions>
+        <!-- TODO:Vuex経由でチェックボックスの真偽値を変更する -->
         <v-checkbox v-if="!isUpdate" class="modal-checkbox" v-model="todo.completed"></v-checkbox>
         <v-layout row wrap justify-end>
           <v-btn v-if="!isUpdate" color="success" @click="openUpdateForm()" outline>編集</v-btn>
@@ -24,7 +25,7 @@
             v-if="isUpdate"
             color="info"
             outline
-            @click="putTodoButton()"
+            @click="putTodoButton(copiedTodo)"
             :disabled="!title || !text"
           >変更</v-btn>
         </v-layout>
@@ -50,6 +51,7 @@ export default {
   },
   data() {
     return {
+      copiedTodo: this.todo,
       title: "",
       text: "",
       isOpen: false,
@@ -79,9 +81,9 @@ export default {
       this.title = "";
       this.text = "";
     },
-    putTodoButton() {
+    putTodoButton(todo) {
       const editTodo = {
-        id: this.todo.id,
+        id: this.copiedTodo.id,
         title: this.title,
         text: this.text
       };

--- a/src/components/Todo/dialogs/TodoDialog.vue
+++ b/src/components/Todo/dialogs/TodoDialog.vue
@@ -19,7 +19,7 @@
         <v-checkbox class="modal-checkbox" v-model="todo.endOfTodo"></v-checkbox>
         <v-btn v-if="!isUpdate" color="success" @click="openUpdateForm()" outline>編集</v-btn>
         <v-btn v-if="isUpdate" color="error" @click="closeUpdateForm()">キャンセル</v-btn>
-        <v-btn v-if="isUpdate" color="info" outline>変更</v-btn>
+        <v-btn v-if="isUpdate" color="info" outline @click="putTodoButton(todo)">変更</v-btn>
 
         <!-- メソッド作成後コメント外す -->
         <!-- <v-btn color="red" flat @click="todo.deleteDialog=true">削除</v-btn> -->
@@ -29,6 +29,7 @@
 </template>
 
 <script>
+import { mapActions } from "vuex";
 export default {
   props: {
     todo: {
@@ -47,6 +48,7 @@ export default {
     };
   },
   methods: {
+    ...mapActions(["putTodo"]),
     open() {
       this.isOpen = true;
     },
@@ -60,13 +62,13 @@ export default {
     },
     closeUpdateForm() {
       this.isUpdate = false;
-      this.title = "",
-      this.text = ""
-    }
+      (this.title = ""), (this.text = "");
+    },
+    putTodoButton(todo) {}
   },
   watch: {
     isOpen() {
-      this.closeUpdateForm()
+      this.closeUpdateForm();
     }
   }
 };

--- a/src/components/Todo/dialogs/TodoDialog.vue
+++ b/src/components/Todo/dialogs/TodoDialog.vue
@@ -16,7 +16,7 @@
       <v-card-text class="modal-todo-date">作成日: {{ todo.date }}</v-card-text>
       <v-spacer></v-spacer>
       <v-card-actions>
-        <v-checkbox class="modal-checkbox" v-model="todo.endOfTodo"></v-checkbox>
+        <v-checkbox class="modal-checkbox" v-model="todo.completed"></v-checkbox>
         <v-btn v-if="!isUpdate" color="success" @click="openUpdateForm()" outline>編集</v-btn>
         <v-btn v-if="isUpdate" color="error" @click="closeUpdateForm()">キャンセル</v-btn>
         <v-btn

--- a/src/components/Todo/dialogs/TodoDialog.vue
+++ b/src/components/Todo/dialogs/TodoDialog.vue
@@ -5,13 +5,13 @@
         <div>{{ todo.title }}</div>
       </v-card-title>
       <v-card-actions class="update-title" v-if="isUpdate">
-        <v-text-field v-model="title" label="title" required></v-text-field>
+        <v-text-field v-model="title" label="title" :rules="inputRule" required></v-text-field>
       </v-card-actions>
 
       <v-divider></v-divider>
       <v-card-text v-if="!isUpdate" class="modal-todo-text">{{ todo.text }}</v-card-text>
       <v-card-actions v-if="isUpdate">
-        <v-text-field v-model="text" label="text" required></v-text-field>
+        <v-text-field v-model="text" label="text" :rules="inputRule" required></v-text-field>
       </v-card-actions>
       <v-card-text class="modal-todo-date">作成日: {{ todo.date }}</v-card-text>
       <v-spacer></v-spacer>
@@ -19,7 +19,13 @@
         <v-checkbox class="modal-checkbox" v-model="todo.endOfTodo"></v-checkbox>
         <v-btn v-if="!isUpdate" color="success" @click="openUpdateForm()" outline>編集</v-btn>
         <v-btn v-if="isUpdate" color="error" @click="closeUpdateForm()">キャンセル</v-btn>
-        <v-btn v-if="isUpdate" color="info" outline @click="putTodoButton(todo)" :disabled="!title || !text">変更</v-btn>
+        <v-btn
+          v-if="isUpdate"
+          color="info"
+          outline
+          @click="putTodoButton(todo)"
+          :disabled="!title || !text"
+        >変更</v-btn>
 
         <!-- メソッド作成後コメント外す -->
         <!-- <v-btn color="red" flat @click="todo.deleteDialog=true">削除</v-btn> -->
@@ -44,7 +50,8 @@ export default {
     return {
       text: "",
       isOpen: false,
-      isUpdate: false
+      isUpdate: false,
+      inputRule: [v => !!v || "必ず入力してください"]
     };
   },
   methods: {

--- a/src/components/Todo/dialogs/TodoDialog.vue
+++ b/src/components/Todo/dialogs/TodoDialog.vue
@@ -50,9 +50,13 @@ export default {
     return {
       text: "",
       isOpen: false,
-      isUpdate: false,
-      inputRule: [v => !!v || "必ず入力してください"]
+      isUpdate: false
     };
+  },
+  computed: {
+    inputRule() {
+      return [v => !!v || "必ず入力してください"];
+    }
   },
   methods: {
     ...mapActions(["putTodo"]),

--- a/src/components/Todo/dialogs/TodoDialog.vue
+++ b/src/components/Todo/dialogs/TodoDialog.vue
@@ -16,16 +16,18 @@
       <v-card-text class="modal-todo-date">作成日: {{ todo.date }}</v-card-text>
       <v-spacer></v-spacer>
       <v-card-actions>
-        <v-checkbox class="modal-checkbox" v-model="todo.completed"></v-checkbox>
-        <v-btn v-if="!isUpdate" color="success" @click="openUpdateForm()" outline>編集</v-btn>
-        <v-btn v-if="isUpdate" color="error" @click="closeUpdateForm()">キャンセル</v-btn>
-        <v-btn
-          v-if="isUpdate"
-          color="info"
-          outline
-          @click="putTodoButton()"
-          :disabled="!title || !text"
-        >変更</v-btn>
+        <v-checkbox v-if="!isUpdate" class="modal-checkbox" v-model="todo.completed"></v-checkbox>
+        <v-layout row wrap justify-end>
+          <v-btn v-if="!isUpdate" color="success" @click="openUpdateForm()" outline>編集</v-btn>
+          <v-btn v-if="isUpdate" color="error" @click="closeUpdateForm()">キャンセル</v-btn>
+          <v-btn
+            v-if="isUpdate"
+            color="info"
+            outline
+            @click="putTodoButton()"
+            :disabled="!title || !text"
+          >変更</v-btn>
+        </v-layout>
 
         <!-- メソッド作成後コメント外す -->
         <!-- <v-btn color="red" flat @click="todo.deleteDialog=true">削除</v-btn> -->

--- a/src/components/Todo/dialogs/TodoDialog.vue
+++ b/src/components/Todo/dialogs/TodoDialog.vue
@@ -19,7 +19,7 @@
         <v-checkbox class="modal-checkbox" v-model="todo.endOfTodo"></v-checkbox>
         <v-btn v-if="!isUpdate" color="success" @click="openUpdateForm()" outline>編集</v-btn>
         <v-btn v-if="isUpdate" color="error" @click="closeUpdateForm()">キャンセル</v-btn>
-        <v-btn v-if="isUpdate" color="info" outline @click="putTodoButton(todo)">変更</v-btn>
+        <v-btn v-if="isUpdate" color="info" outline @click="putTodoButton(todo)" :disabled="!title || !text">変更</v-btn>
 
         <!-- メソッド作成後コメント外す -->
         <!-- <v-btn color="red" flat @click="todo.deleteDialog=true">削除</v-btn> -->
@@ -62,9 +62,18 @@ export default {
     },
     closeUpdateForm() {
       this.isUpdate = false;
-      (this.title = ""), (this.text = "");
+      this.title = "";
+      this.text = "";
     },
-    putTodoButton(todo) {}
+    putTodoButton(todo) {
+      const editTodo = {
+        id: todo.id,
+        title: this.title,
+        text: this.text
+      };
+      this.putTodo(editTodo);
+      this.closeUpdateForm();
+    }
   },
   watch: {
     isOpen() {

--- a/src/components/Todo/dialogs/TodoDialog.vue
+++ b/src/components/Todo/dialogs/TodoDialog.vue
@@ -23,7 +23,7 @@
           v-if="isUpdate"
           color="info"
           outline
-          @click="putTodoButton(todo)"
+          @click="putTodoButton()"
           :disabled="!title || !text"
         >変更</v-btn>
 
@@ -77,9 +77,9 @@ export default {
       this.title = "";
       this.text = "";
     },
-    putTodoButton(todo) {
+    putTodoButton() {
       const editTodo = {
-        id: todo.id,
+        id: this.todo.id,
         title: this.title,
         text: this.text
       };


### PR DESCRIPTION
# 行ったこと

## putTodoButtonの作成
idとタイトルとテキストを`editTodo`にまとめ、`actions.putTodo`に渡します。
その後、`closeUpdateForm`で編集画面を閉じます

## エラー
- タイトルが空白の場合
- テキストが空白の場合
エラーは`putTodoButton`メソッドには入れず、`Vuetify`の機能を使って、エラーの場合は送信ボタンが押せないようにしました。
今回のTodo変更方法の場合、基本的にIDと合致するTodoが無い状況はおそらくできないと思うので、エラーハンドリングはしてません

### 成功時
![putTodo suc](https://user-images.githubusercontent.com/46712701/61534967-fb8c2880-aa6b-11e9-8daf-18a3def364f7.gif)

### 失敗時
![putTodo err](https://user-images.githubusercontent.com/46712701/61534986-0a72db00-aa6c-11e9-823a-88eb023cd904.gif)

参考
https://v1.vuetifyjs.com/ja/components/forms#example-validation-with-submit-and-clear