### PR TITLE
feature/mutations.removeTodoの作成

### DIFF
--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -9,5 +9,5 @@ export default {
     const index = state.todos.findIndex(todo => editTodo.id === todo.id);
     state.todos[index].title = editTodo.title;
     state.todos[index].text = editTodo.text;
-  }
+  },
 };

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -10,4 +10,8 @@ export default {
     state.todos[index].title = editTodo.title;
     state.todos[index].text = editTodo.text;
   },
+  removeTodo(state, id) {
+    const index = state.todos.findIndex(todo => id === todo.id);
+    state.todos.splice(index, 1);
+  }
 };

--- a/tests/unit/store/mutations.spec.js
+++ b/tests/unit/store/mutations.spec.js
@@ -25,4 +25,12 @@ describe("test mutations.js", () => {
     mutations.updateTodo(state, todo);
     expect(state.todos[2]).toEqual(todo);
   });
+  it("mutations.removeTodoは指定したidと紐つく配列内のtodoを一件削除する", () => {
+    const oldTodos = state.todos.slice();
+
+    const id = 1;
+
+    mutations.removeTodo(state, id);
+    expect(state.todos).not.toEqual(oldTodos);
+  })
 });

--- a/tests/unit/store/mutations.spec.js
+++ b/tests/unit/store/mutations.spec.js
@@ -32,5 +32,5 @@ describe("test mutations.js", () => {
 
     mutations.removeTodo(state, id);
     expect(state.todos).not.toEqual(oldTodos);
-  })
+  });
 });


### PR DESCRIPTION
# 機能
`state.todos`の配列`todos`内から、removeTodoに渡されたidの値と合致するTodoを一件削除する

# テスト
mutations.removeTodoは指定したidと紐つく配列内のtodoを一件削除する
<img width="472" alt="スクリーンショット 2019-07-20 13 56 32" src="https://user-images.githubusercontent.com/46712701/61574155-39359380-aaf6-11e9-8b79-7afbf4c94ffa.png">
