### PR TITLE
feature/actions.deleteTodo,todos.removeTodoの作成

### DIFF
--- a/src/data/todos.js
+++ b/src/data/todos.js
@@ -47,10 +47,10 @@ export default {
   },
   removeTodo: id => {
     const index = todos.findIndex(todo => id === todo.id);
-    if (!index) {
+    if (index === -1) {
       throw new Error("idと合致するTodoはありません");
     }
-    const todo = todos.todo.splive(index, 1);
+    const todo = todos.splice(index, 1)[0];
     return todo;
   }
 };

--- a/src/data/todos.js
+++ b/src/data/todos.js
@@ -37,12 +37,20 @@ export default {
   },
   updateTodo: editTodo => {
     const todo = todos.find(todo => editTodo.id === todo.id);
-    if(!todo) {
+    if (!todo) {
       throw new Error("idと合致するTodoはありません");
     }
     todo.title = editTodo.title;
     todo.text = editTodo.text;
 
+    return todo;
+  },
+  removeTodo: id => {
+    const index = todos.findIndex(todo => id === todo.id);
+    if (!index) {
+      throw new Error("idと合致するTodoはありません");
+    }
+    const todo = todos.todo.splive(index, 1);
     return todo;
   }
 };

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -18,7 +18,7 @@ export default {
   },
   deleteTodo: ({ commit }, id) => {
     try {
-      const todo = todo.removeTodo(id);
+      const todo = todos.removeTodo(id);
       commit("removeTodo", todo);
     } catch (e) {
       throw e;

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -18,8 +18,8 @@ export default {
   },
   deleteTodo: ({ commit }, id) => {
     try {
-      const todo = todos.removeTodo(id);
-      commit("removeTodo", todo);
+      todos.removeTodo(id);
+      commit("removeTodo", id);
     } catch (e) {
       throw e;
     }

--- a/tests/unit/store/actions.spec.js
+++ b/tests/unit/store/actions.spec.js
@@ -55,7 +55,23 @@ describe("test actions.js", () => {
     };
 
     expect(() => {
-      actions.putTodo({commit}, missingTodo);
+      actions.putTodo({ commit }, missingTodo);
     }).toThrow("idと合致するTodoはありません");
+  });
+  it("deleteTodo test", () => {
+    const commit = jest.fn();
+    const id = 1;
+
+    const oldTodos = todos.findAll();
+    const oldTodo = oldTodos.find(todo => id === todo.id);
+
+    actions.deleteTodo({ commit }, id);
+    expect(commit).toHaveBeenCalledWith("removeTodo", {
+      id: id,
+      title: oldTodo.title,
+      text: oldTodo.text,
+      date: oldTodo.date,
+      completed: oldTodo.completed
+    });
   });
 });

--- a/tests/unit/store/actions.spec.js
+++ b/tests/unit/store/actions.spec.js
@@ -62,17 +62,8 @@ describe("test actions.js", () => {
     const commit = jest.fn();
     const id = 1;
 
-    const oldTodos = todos.findAll();
-    const oldTodo = oldTodos.find(todo => id === todo.id);
-
     actions.deleteTodo({ commit }, id);
-    expect(commit).toHaveBeenCalledWith("removeTodo", {
-      id: id,
-      title: oldTodo.title,
-      text: oldTodo.text,
-      date: oldTodo.date,
-      completed: oldTodo.completed
-    });
+    expect(commit).toHaveBeenCalledWith("removeTodo", id);
   });
   it("actions.deleteTodoはidと合致するTodoがない場合、エラーを返す", () => {
     const commit = jest.fn();

--- a/tests/unit/store/actions.spec.js
+++ b/tests/unit/store/actions.spec.js
@@ -74,4 +74,12 @@ describe("test actions.js", () => {
       completed: oldTodo.completed
     });
   });
+  it("deleteTodo err test", () => {
+    const commit = jest.fn();
+    const invalidId = 999999999999999999;
+
+    expect(() => {
+      actions.deleteTodo({ commit }, invalidId);
+    }).toThrow("idと合致するTodoはありません");
+  })
 });

--- a/tests/unit/store/actions.spec.js
+++ b/tests/unit/store/actions.spec.js
@@ -58,7 +58,7 @@ describe("test actions.js", () => {
       actions.putTodo({ commit }, missingTodo);
     }).toThrow("idと合致するTodoはありません");
   });
-  it("deleteTodo test", () => {
+  it("actions.deleteTodoはmutations.removeTodoにid値を渡す、また、idと合致する配列内のTodo一件を削除する", () => {
     const commit = jest.fn();
     const id = 1;
 
@@ -74,7 +74,7 @@ describe("test actions.js", () => {
       completed: oldTodo.completed
     });
   });
-  it("deleteTodo err test", () => {
+  it("actions.deleteTodoはidと合致するTodoがない場合、エラーを返す", () => {
     const commit = jest.fn();
     const invalidId = 999999999999999999;
 


### PR DESCRIPTION
# 機能

## actions.deleteTodo
IDの値を`todos.removeTodo`に渡し、removeTodoが問題なく実行された場合、IDの値を`mutations.removeTodo`に渡す。<br>
removeTodoで問題が発生した場合、エラーを返す

## todos.removeTodo
渡されたIDの値と合致するTodo一件を配列から削除する。<br>
配列から合致するTodoが見つからない場合、エラーを返す

# テスト

## actions.deleteTodoはmutations.removeTodoにid値を渡す、また、idと合致する配列内のTodo一件を削除する
<img width="472" alt="スクリーンショット 2019-07-21 21 27 18" src="https://user-images.githubusercontent.com/46712701/61591173-59507a00-abfe-11e9-9220-5b1276b9f16c.png">

## actions.deleteTodoはidと合致するTodoがない場合、エラーを返す

<img width="472" alt="スクリーンショット 2019-07-21 21 22 39" src="https://user-images.githubusercontent.com/46712701/61591169-450c7d00-abfe-11e9-90e8-df4c92d9b4d5.png">
