### PR TITLE
feature/Todo削除メソッドをvueに組み込み

### DIFF
--- a/src/components/Todo/dialogs/DeleteDialog.vue
+++ b/src/components/Todo/dialogs/DeleteDialog.vue
@@ -6,7 +6,7 @@
       </v-card-title>
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn color="red" flat>はい</v-btn>
+        <v-btn color="red" @click="deleteTodoButton()" flat>はい</v-btn>
         <v-btn color="gray" flat @click="close()">いいえ</v-btn>
       </v-card-actions>
     </v-card>
@@ -14,6 +14,7 @@
 </template>
 
 <script>
+import { mapActions } from "vuex";
 export default {
   props: {
     todo: {
@@ -30,11 +31,15 @@ export default {
     };
   },
   methods: {
+    ...mapActions(["deleteTodo"]),
     open() {
       this.isOpen = true;
     },
     close() {
       this.isOpen = false;
+    },
+    deleteTodoButton() {
+      this.deleteTodo(this.todo.id);
     }
   }
 };


### PR DESCRIPTION
# 行ったこと

## deleteTodoButtonの作成
×ボタンをクリックしたカードのTodoIDをdeleteTodoに渡します。
エラーハンドリングは特にありません。

前回`putTodoButton`メソッドの時は、`props`のIDをコピーしたデータを渡しましたが、今回はpropsから直接受け渡されるようにしました(vue内で直接変更している訳ではないので)
![deleteTodo](https://user-images.githubusercontent.com/46712701/61592258-f49c1c00-ac0b-11e9-963c-bb8bbb17f75c.gif)
