### PR TITLE
fix:mutations.spac.jsの修正

### DIFF
--- a/tests/unit/store/mutations.spec.js
+++ b/tests/unit/store/mutations.spec.js
@@ -29,38 +29,46 @@ describe("test mutations.js", () => {
       });
       todos.push({ ...todo });
     }
+
     mutations.setTodos(state, todos);
     expect(state.todos).toEqual(todos);
   });
   it("mutations.addTodoはstate.todosの末尾に第二引数をpushする", () => {
+    const addingTodoID = nextID;
+
     const todo = new Todo({
       title: "タイトル" + nextID,
       text: "詳細分" + nextID
     });
 
-    const todoId = nextID - 2;
-
     mutations.addTodo(state, { ...todo });
-    expect(state.todos[todoId]).toEqual(todo);
+
+    const addedTodo = state.todos.find(todo => addingTodoID === todo.id);
+
+    expect(addedTodo).toEqual(todo);
   });
   it("mutations.updateTodoは指定したidと紐つく配列内のtodoを内容を変更する", () => {
-    const id = 3
+    const updatingTodoID = 3;
 
-    const oldTodo = state.todos.find(todo => id === todo.id)
+    const oldTodo = state.todos.find(todo => updatingTodoID === todo.id);
 
-    const todo = { id: id, title: "update title", text: "update text" };
+    const todo = {
+      id: updatingTodoID,
+      title: "update title",
+      text: "update text"
+    };
     mutations.updateTodo(state, todo);
 
-    const updatedTodo = state.todos.find(todo => id === todo.id)
+    const updatedTodo = state.todos.find(todo => updatingTodoID === todo.id);
 
     expect(oldTodo).toEqual(updatedTodo);
   });
   it("mutations.removeTodoは指定したidと紐つく配列内のtodoを一件削除する", () => {
     const oldTodos = state.todos.slice();
 
-    const id = 1;
+    const removingTodoID = 1;
 
-    mutations.removeTodo(state, id);
+    mutations.removeTodo(state, removingTodoID);
     expect(state.todos).not.toEqual(oldTodos);
   });
 });

--- a/tests/unit/store/mutations.spec.js
+++ b/tests/unit/store/mutations.spec.js
@@ -1,4 +1,6 @@
 import mutations from "@/store/mutations";
+import moment from "moment";
+moment.locale("ja");
 
 const state = {
   todos: []

--- a/tests/unit/store/mutations.spec.js
+++ b/tests/unit/store/mutations.spec.js
@@ -18,12 +18,6 @@ class Todo {
   }
 }
 
-const findTodo = id => {
-  // state.todosをコピーして渡している
-  const copiedTodos = state.todos.slice();
-  const todo = copiedTodos.find(todo => id === todo.id);
-  return todo;
-};
 
 describe("test mutations.js", () => {
   it("mutations.setTodosはstate.todosに第二引数を渡す", () => {
@@ -41,36 +35,33 @@ describe("test mutations.js", () => {
     expect(state.todos).toEqual(todos);
   });
   it("mutations.addTodoはstate.todosの末尾に第二引数をpushする", () => {
-    const addingTodoID = nextID;
-
     const todo = new Todo({
       title: "タイトル" + nextID,
       text: "詳細分" + nextID
     });
 
-    mutations.addTodo(state, { ...todo });
+    mutations.addTodo(state, todo)
 
-    const addedTodo = findTodo(addingTodoID);
-
-    expect(addedTodo).toEqual(todo);
+    expect(state.todos[5]).toEqual(todo);
   });
   it("mutations.updateTodoは指定したidと紐つく配列内のtodoを内容を変更する", async () => {
     const updatingTodoID = 3;
-
-    const oldTodo = findTodo(updatingTodoID);
-    console.log("mutations.updateTodo前: ", oldTodo);
 
     const todo = {
       id: updatingTodoID,
       title: "update title",
       text: "update text"
     };
+
     mutations.updateTodo(state, todo);
-    console.log("mutations.updateTodo後: ", oldTodo);
 
-    const updatedTodo = findTodo(updatingTodoID);
-
-    expect(oldTodo).not.toEqual(updatedTodo);
+    expect(state.todos[2]).toEqual({
+      id: updatingTodoID,
+      title: todo.title,
+      text: todo.text,
+      date: state.todos[2].date,
+      completed: false
+    });
   });
   it("mutations.removeTodoは指定したidと紐つく配列内のtodoを一件削除する", () => {
     const oldTodos = state.todos.slice();

--- a/tests/unit/store/mutations.spec.js
+++ b/tests/unit/store/mutations.spec.js
@@ -6,26 +6,54 @@ const state = {
   todos: []
 };
 
+let nextID = 1;
+
+class Todo {
+  constructor({ title, text }) {
+    this.id = nextID++;
+    this.title = title;
+    this.text = text;
+    this.date = moment().format("YYYY年 MM月 Do(ddd), kk時mm分 ");
+    this.completed = false;
+  }
+}
+
 describe("test mutations.js", () => {
   it("mutations.setTodosはstate.todosに第二引数を渡す", () => {
-    const todos = [
-      { id: 1, title: "test title1", text: "test text1" },
-      { id: 2, title: "test title2", text: "test text2" }
-    ];
+    const todos = [];
+
+    for (let i = 0; i < 5; i++) {
+      const todo = new Todo({
+        title: "タイトル" + i,
+        text: `詳細分` + i
+      });
+      todos.push({ ...todo });
+    }
     mutations.setTodos(state, todos);
     expect(state.todos).toEqual(todos);
   });
   it("mutations.addTodoはstate.todosの末尾に第二引数をpushする", () => {
-    const todo = { id: 3, title: "test title3", text: "test text3" };
+    const todo = new Todo({
+      title: "タイトル" + nextID,
+      text: "詳細分" + nextID
+    });
 
-    mutations.addTodo(state, todo);
-    expect(state.todos[2]).toEqual(todo);
+    const todoId = nextID - 2;
+
+    mutations.addTodo(state, { ...todo });
+    expect(state.todos[todoId]).toEqual(todo);
   });
   it("mutations.updateTodoは指定したidと紐つく配列内のtodoを内容を変更する", () => {
-    const todo = { id: 3, title: "update title", text: "update text" };
+    const id = 3
 
+    const oldTodo = state.todos.find(todo => id === todo.id)
+
+    const todo = { id: id, title: "update title", text: "update text" };
     mutations.updateTodo(state, todo);
-    expect(state.todos[2]).toEqual(todo);
+
+    const updatedTodo = state.todos.find(todo => id === todo.id)
+
+    expect(oldTodo).toEqual(updatedTodo);
   });
   it("mutations.removeTodoは指定したidと紐つく配列内のtodoを一件削除する", () => {
     const oldTodos = state.todos.slice();

--- a/tests/unit/store/mutations.spec.js
+++ b/tests/unit/store/mutations.spec.js
@@ -18,6 +18,13 @@ class Todo {
   }
 }
 
+const findTodo = id => {
+  // state.todosをコピーして渡している
+  const copiedTodos = state.todos.slice();
+  const todo = copiedTodos.find(todo => id === todo.id);
+  return todo;
+};
+
 describe("test mutations.js", () => {
   it("mutations.setTodosはstate.todosに第二引数を渡す", () => {
     const todos = [];
@@ -43,14 +50,15 @@ describe("test mutations.js", () => {
 
     mutations.addTodo(state, { ...todo });
 
-    const addedTodo = state.todos.find(todo => addingTodoID === todo.id);
+    const addedTodo = findTodo(addingTodoID);
 
     expect(addedTodo).toEqual(todo);
   });
-  it("mutations.updateTodoは指定したidと紐つく配列内のtodoを内容を変更する", () => {
+  it("mutations.updateTodoは指定したidと紐つく配列内のtodoを内容を変更する", async () => {
     const updatingTodoID = 3;
 
-    const oldTodo = state.todos.find(todo => updatingTodoID === todo.id);
+    const oldTodo = findTodo(updatingTodoID);
+    console.log("mutations.updateTodo前: ", oldTodo);
 
     const todo = {
       id: updatingTodoID,
@@ -58,10 +66,11 @@ describe("test mutations.js", () => {
       text: "update text"
     };
     mutations.updateTodo(state, todo);
+    console.log("mutations.updateTodo後: ", oldTodo);
 
-    const updatedTodo = state.todos.find(todo => updatingTodoID === todo.id);
+    const updatedTodo = findTodo(updatingTodoID);
 
-    expect(oldTodo).toEqual(updatedTodo);
+    expect(oldTodo).not.toEqual(updatedTodo);
   });
   it("mutations.removeTodoは指定したidと紐つく配列内のtodoを一件削除する", () => {
     const oldTodos = state.todos.slice();
@@ -69,6 +78,7 @@ describe("test mutations.js", () => {
     const removingTodoID = 1;
 
     mutations.removeTodo(state, removingTodoID);
+
     expect(state.todos).not.toEqual(oldTodos);
   });
 });


### PR DESCRIPTION
# 問題
修正前の`mutations.spec.js`は、Todoオブジェクトの値が実際の`data.todos`から作成されるTodoオブジェクトと違っていた。

# 修正点

## Todoクラスの作成
テストjs内に`Todo`クラスを作成、テストごとにTodoオブジェクトを`data.todos`で作成されるオブジェクトと同じ形に作成されるようにしました

# テスト結果

<img width="472" alt="スクリーンショット 2019-07-22 10 03 19" src="https://user-images.githubusercontent.com/46712701/61599916-5a1df600-ac68-11e9-85d8-2b4ab8f1a435.png">


## ~~テスト方法の変更~~
~~従来のテストは、`expect`に静的な値を入れていましたが、今回は`nextID`等を活用して、動的に配列内のTodoを追ってテストができるようにしました。~~

## ~~問題発生~~

~~`updateTodo`のテストにて、コピーした配列から会得したデータがupdateTodo実行前と実行後で変わってしまいます。~~
~~メソッド内にて`stete.todo.slice()`と、配列はコピーされているはずなのですが、どこのコードが原因なのかがわかりません。~~
~~お知恵を貸していただけたら大変助かります~~
<img width="472" alt="スクリーンショット 2019-07-22 1 31 57" src="https://user-images.githubusercontent.com/46712701/61593930-eefd0100-ac20-11e9-862b-0391c2b956b3.png">
