### PR TITLE
feature/actions.changeTodo, todos.switchTodoの作成

### DIFF
--- a/src/data/todos.js
+++ b/src/data/todos.js
@@ -58,8 +58,6 @@ export default {
     if (index === -1) {
       throw new Error("idと合致するTodoはありません");
     }
-    const todo = (todos[index].completed = !todos[index].completed);
-
-    return todo;
+    todos[index].completed = !todos[index].completed;
   }
 };

--- a/src/data/todos.js
+++ b/src/data/todos.js
@@ -50,6 +50,7 @@ export default {
     if (index === -1) {
       throw new Error("idと合致するTodoはありません");
     }
+    // returnは不要なので別ブランチで削除
     const todo = todos.splice(index, 1)[0];
     return todo;
   },

--- a/src/data/todos.js
+++ b/src/data/todos.js
@@ -52,5 +52,14 @@ export default {
     }
     const todo = todos.splice(index, 1)[0];
     return todo;
+  },
+  switchCompleted: id => {
+    const index = todos.findIndex(todo => id === todo.id);
+    if (index === -1) {
+      throw new Error("idと合致するTodoはありません");
+    }
+    const todo = (todos[index].completed = !todos[index].completed);
+
+    return todo;
   }
 };

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -23,5 +23,13 @@ export default {
     } catch (e) {
       throw e;
     }
+  },
+  changeCompleted: ({ commit }, id) => {
+    try {
+      todos.switchCompleted(id);
+      commit("switchCompleted", id);
+    } catch (e) {
+      throw e;
+    }
   }
 };

--- a/tests/unit/store/actions.spec.js
+++ b/tests/unit/store/actions.spec.js
@@ -72,5 +72,12 @@ describe("test actions.js", () => {
     expect(() => {
       actions.deleteTodo({ commit }, invalidId);
     }).toThrow("idと合致するTodoはありません");
-  })
+  });
+  it("actions.changeCompletedはmutations.switchCompletedにid値を渡す、また、idと合致するtodo.completedの真偽値を反転する", () => {
+    const commit = jest.fn();
+    const id = 2;
+
+    actions.changeCompleted({ commit }, id);
+    expect(commit).toHaveBeenCalledWith("switchCompleted", id);
+  });
 });

--- a/tests/unit/store/actions.spec.js
+++ b/tests/unit/store/actions.spec.js
@@ -80,4 +80,12 @@ describe("test actions.js", () => {
     actions.changeCompleted({ commit }, id);
     expect(commit).toHaveBeenCalledWith("switchCompleted", id);
   });
+  it("actions.changeCompletedはidと合致するTodoがない場合、エラーを返す", () => {
+    const commit = jest.fn();
+    const invalidId = 999999999999999999;
+
+    expect(() => {
+      actions.changeCompleted({ commit }, invalidId);
+    }).toThrow("idと合致するTodoはありません");
+  });
 });


### PR DESCRIPTION
# 機能

## actions.changeCompleted
ID値を`todos.switchCompleted`に渡し、問題なく実行した場合、ID値を`mutations.switchCompleted`に渡します。

`todos.switchCompleted`で問題が発生した場合、エラーを返します。

## todos.switchCompleted
渡されたID値と合致するTodo一件の`completed`を反転させます。

IDと一致するTodoが配列から見つからない場合、エラーを返します。

# テスト
-  actions.changeCompletedはmutations.switchCompletedにid値を渡す、また、idと合致するtodo.completedの真偽値を反転する

- actions.changeCompletedはidと合致するTodoがない場合、エラーを返す

<img width="472" alt="スクリーンショット 2019-07-22 15 00 38" src="https://user-images.githubusercontent.com/46712701/61609780-2d7ed400-ac92-11e9-880e-5d29650c8220.png">


